### PR TITLE
delete_item.py: add ellipsis to folder paths

### DIFF
--- a/src/delete_item.py
+++ b/src/delete_item.py
@@ -24,7 +24,7 @@ else:
         target = c['target'][-25:]
         wf.setItem(
             title=name,
-            subtitle=f'{source} → {target} (\u21E7 to see full path)',
+            subtitle=f'...{source} → ...{target} (\u21E7 to see full path)',
             arg=f'{uid}|{name}|||DELETE',
             quicklookurl=f'file://{rs.getHelpfile(uid)}'
         )


### PR DESCRIPTION
The other options do it, but deleting was just cutting the name without the `...`.